### PR TITLE
Binary expression

### DIFF
--- a/src/__tests__/typeChecker.test.ts
+++ b/src/__tests__/typeChecker.test.ts
@@ -3,36 +3,36 @@ import { createContext } from '../index'
 import { parse } from '../parser'
 import { typeCheck } from '../typeChecker'
 
-describe('binary expressions', function() {
-    it('errors when adding number to string', function() {
-        const context = createContext(1)
-        const code = "const x = 5; const y = 'bob'; const z = x + y;"
-        const program = parse(code, context);
-        expect(() => typeCheck(program)).toThrowError()
-    })
+describe('binary expressions', () => {
+  it('errors when adding number to string', () => {
+    const context = createContext(1)
+    const code = "const x = 5; const y = 'bob'; const z = x + y;"
+    const program = parse(code, context)
+    expect(() => typeCheck(program)).toThrowError()
+  })
 
-    it('no errors when adding number to number', function() {
-        const context = createContext(1)
-        const code = "const x = 5; const y = 6; const z = x + y;"
-        const program = parse(code, context);
-        typeCheck(program);
-        expect(() => typeCheck(program)).not.toThrowError()
-    })
+  it('no errors when adding number to number', () => {
+    const context = createContext(1)
+    const code = 'const x = 5; const y = 6; const z = x + y;'
+    const program = parse(code, context)
+    typeCheck(program)
+    expect(() => typeCheck(program)).not.toThrowError()
+  })
 
-    it('no errors when comparing number with number', function() {
-        const context = createContext(1)
-        const code = "const x = 5; const y = 6; const z = x === y;"
-        const program = parse(code, context);
-        typeCheck(program);
-        expect(() => typeCheck(program)).not.toThrowError()
-    })
+  it('no errors when comparing number with number', () => {
+    const context = createContext(1)
+    const code = 'const x = 5; const y = 6; const z = x === y;'
+    const program = parse(code, context)
+    typeCheck(program)
+    expect(() => typeCheck(program)).not.toThrowError()
+  })
 
-    // NOTE currently fails, can fix once we introduce polymorphic types
-    // it('no errors when comparing string with string', function() {
-    //     const context = createContext(1)
-    //     const code = "const x = 'test'; const y = 'foo'; const z = x === y;"
-    //     const program = parse(code, context);
-    //     typeCheck(program);
-    //     expect(() => typeCheck(program)).not.toThrowError()
-    // })
+  // NOTE currently fails, can fix once we introduce polymorphic types
+  // it('no errors when comparing string with string', () => {
+  //     const context = createContext(1)
+  //     const code = "const x = 'test'; const y = 'foo'; const z = x === y;"
+  //     const program = parse(code, context);
+  //     typeCheck(program);
+  //     expect(() => typeCheck(program)).not.toThrowError()
+  // })
 })

--- a/src/__tests__/typeChecker.test.ts
+++ b/src/__tests__/typeChecker.test.ts
@@ -1,0 +1,38 @@
+// import { typeCheck } from '../typeChecker'
+import { createContext } from '../index'
+import { parse } from '../parser'
+import { typeCheck } from '../typeChecker'
+
+describe('binary expressions', function() {
+    it('errors when adding number to string', function() {
+        const context = createContext(1)
+        const code = "const x = 5; const y = 'bob'; const z = x + y;"
+        const program = parse(code, context);
+        expect(() => typeCheck(program)).toThrowError()
+    })
+
+    it('no errors when adding number to number', function() {
+        const context = createContext(1)
+        const code = "const x = 5; const y = 6; const z = x + y;"
+        const program = parse(code, context);
+        typeCheck(program);
+        expect(() => typeCheck(program)).not.toThrowError()
+    })
+
+    it('no errors when comparing number with number', function() {
+        const context = createContext(1)
+        const code = "const x = 5; const y = 6; const z = x === y;"
+        const program = parse(code, context);
+        typeCheck(program);
+        expect(() => typeCheck(program)).not.toThrowError()
+    })
+
+    // NOTE currently fails, can fix once we introduce polymorphic types
+    // it('no errors when comparing string with string', function() {
+    //     const context = createContext(1)
+    //     const code = "const x = 'test'; const y = 'foo'; const z = x === y;"
+    //     const program = parse(code, context);
+    //     typeCheck(program);
+    //     expect(() => typeCheck(program)).not.toThrowError()
+    // })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { AsyncScheduler, PreemptiveScheduler } from './schedulers'
 import { areBreakpointsSet, setBreakpointAtLine } from './stdlib/inspector'
 import { codify, getEvaluationSteps } from './substituter'
 import { transpile } from './transpiler'
-import { typeCheck } from './typeChecker'
+// import { typeCheck } from './typeChecker'
 import {
   Context,
   Error as ResultError,
@@ -164,7 +164,7 @@ export async function runInContext(
 
   verboseErrors = getFirstLine(code) === 'enable verbose'
   const program = parse(code, context)
-  typeCheck(program)
+  // typeCheck(program)
   if (!program) {
     return resolvedErrorPromise
   }

--- a/src/typeChecker.ts
+++ b/src/typeChecker.ts
@@ -10,29 +10,38 @@ export function typeCheck(program: es.Program | undefined): void {
   if (program === undefined || program.body[0] === undefined) {
     return
   }
-  // console.log(program)
-  const ctx: Ctx = { next: 0, env: {} }
+  const ctx: Ctx = { next: 0, env: initialEnv }
   try {
     program.body.forEach(node => {
-      if (1 + 1 === 0) {
-        infer(node, ctx)
-      }
+      infer(node, ctx)
+      // if (1 + 1 === 0) {
+      //   infer(node, ctx)
+      // }
     })
   } catch (e) {
     console.log(e)
+    throw e
   }
 }
 
 // Type Definitions
+// An environment maps variables (which are expressions) to types. Do not confuse with a 
+// substitution which maps type variables to types
 interface Env {
   [name: string]: TYPE
 }
 
+/**
+ * Context contains the environment along with some other information that we might need
+ */
 interface Ctx {
-  next: number
-  env: Env
+  next: number // next type variable to be generated
+  env: Env // mapping of variables in scope to types
 }
 
+// a map of type variable names to types assigned to them
+// A substitution maps type variables to types while an environment maps variables (which are 
+// expressions) to types
 interface Subsitution {
   [key: string]: TYPE
 }
@@ -115,10 +124,24 @@ function applySubstToType(subst: Subsitution, type: TYPE): TYPE {
   }
 }
 
+/**
+ * Replace type variables in a type that are present in a given substitution 
+ * and return the type with those variables with their substituted values
+ * e.g. applying substitution of {"a": Bool, "b": Int} to type (a -> b) will give 
+ * the type: Bool -> Int
+ * @param subst 
+ * @param types 
+ */
 function applySubstToTypes(subst: Subsitution, types: TYPE[]): TYPE[] {
   return types.map(type => applySubstToType(subst, type))
 }
 
+/**
+ * Applies the first substitution to the types of the second one and then
+ * combines the result with the first substitution
+ * @param s1 
+ * @param s2 
+ */
 function composeSubsitutions(s1: Subsitution, s2: Subsitution): Subsitution {
   const composedSubst: Subsitution = {}
   Object.keys(s2).forEach(key => {
@@ -176,6 +199,23 @@ type TYPE = NAMED | VAR | FUNCTION
 function infer(node: es.Node, ctx: Ctx): [TYPE, Subsitution] {
   const env = ctx.env
   switch (node.type) {
+    case 'BinaryExpression':  {
+      const [inferredLeft, leftSubst] = infer(node.left, ctx)
+      const [inferredRight, rightSubst] = infer(node.right, ctx)
+      let composedSubst = composeSubsitutions(leftSubst, rightSubst)
+
+      const funcType = env[node.operator] as FUNCTION;
+      const newType = newTypeVar(ctx);
+      const subst1 = unify({ 
+        nodeType: 'Function', 
+        fromTypes: [inferredLeft, inferredRight], 
+        toType: newType}, 
+      funcType)
+
+      composedSubst = composeSubsitutions(composedSubst, subst1)
+      const inferredReturnType = applySubstToType(composedSubst, funcType.toType)
+      return [inferredReturnType, composedSubst]
+    }
     case 'ExpressionStatement': {
       const inferred = infer(node.expression, ctx)
       return [{ nodeType: 'Named', name: 'undefined' }, inferred[1]]
@@ -218,7 +258,6 @@ function infer(node: es.Node, ctx: Ctx): [TYPE, Subsitution] {
     case 'Identifier': {
       const identifierName = node.name
       if (env[identifierName]) {
-        // console.log(env[identifierName])
         return [env[identifierName], {}]
       }
       throw Error('Undefined identifier')
@@ -259,7 +298,6 @@ function infer(node: es.Node, ctx: Ctx): [TYPE, Subsitution] {
         fromTypes: applySubstToTypes(subst, newTypes),
         toType: bodyType
       }
-      console.log(inferredType)
       return [inferredType, subst]
     }
     case 'VariableDeclaration': {
@@ -302,11 +340,49 @@ function infer(node: es.Node, ctx: Ctx): [TYPE, Subsitution] {
       // consolidate new substitutions
       const finalSubst = composeSubsitutions(subst5, subst6)
       const inferredReturnType = applySubstToType(finalSubst, funcType1.toType)
-      console.log(inferredReturnType)
-      console.log(finalSubst)
       return [inferredReturnType, finalSubst]
     }
     default:
       return [{ nodeType: 'Named', name: 'undefined' }, {}]
   }
 }
+
+//=======================================
+// Private Helper Parsing Functions
+//=======================================
+
+function tNamedBool(): NAMED {
+  return {
+      nodeType: "Named",
+      name: 'boolean'
+  };
+}
+
+function tNamedNumber(): NAMED {
+  return {
+    nodeType: "Named",
+    name: "number"
+  }
+}
+
+function tFunc(...types: TYPE[]): FUNCTION {
+  const fromTypes = types.slice(0, -1)
+  const toType = types.slice(-1)[0]
+  return {
+      nodeType: 'Function',
+      fromTypes: fromTypes,
+      toType: toType
+  };
+}
+
+const initialEnv = {
+    "true": tNamedBool(),
+    "false": tNamedBool(),
+    "!": tFunc(tNamedBool(), tNamedBool()),
+    "&&": tFunc(tNamedBool(), tNamedBool(), tNamedBool()),
+    "||": tFunc(tNamedBool(), tNamedBool(), tNamedBool()),
+    // NOTE for now just handle for Number === Number
+    "===": tFunc(tNamedNumber(), tNamedNumber(), tNamedBool()),
+    // "Bool==": tFunc(tNamedBool(), tNamedBool(), tNamedBool()),
+    "+": tFunc(tNamedNumber(), tNamedNumber(), tNamedNumber())
+};

--- a/src/typeChecker.ts
+++ b/src/typeChecker.ts
@@ -25,7 +25,7 @@ export function typeCheck(program: es.Program | undefined): void {
 }
 
 // Type Definitions
-// An environment maps variables (which are expressions) to types. Do not confuse with a 
+// An environment maps variables (which are expressions) to types. Do not confuse with a
 // substitution which maps type variables to types
 interface Env {
   [name: string]: TYPE
@@ -40,7 +40,7 @@ interface Ctx {
 }
 
 // a map of type variable names to types assigned to them
-// A substitution maps type variables to types while an environment maps variables (which are 
+// A substitution maps type variables to types while an environment maps variables (which are
 // expressions) to types
 interface Subsitution {
   [key: string]: TYPE
@@ -125,12 +125,12 @@ function applySubstToType(subst: Subsitution, type: TYPE): TYPE {
 }
 
 /**
- * Replace type variables in a type that are present in a given substitution 
+ * Replace type variables in a type that are present in a given substitution
  * and return the type with those variables with their substituted values
- * e.g. applying substitution of {"a": Bool, "b": Int} to type (a -> b) will give 
+ * e.g. applying substitution of {"a": Bool, "b": Int} to type (a -> b) will give
  * the type: Bool -> Int
- * @param subst 
- * @param types 
+ * @param subst
+ * @param types
  */
 function applySubstToTypes(subst: Subsitution, types: TYPE[]): TYPE[] {
   return types.map(type => applySubstToType(subst, type))
@@ -139,8 +139,8 @@ function applySubstToTypes(subst: Subsitution, types: TYPE[]): TYPE[] {
 /**
  * Applies the first substitution to the types of the second one and then
  * combines the result with the first substitution
- * @param s1 
- * @param s2 
+ * @param s1
+ * @param s2
  */
 function composeSubsitutions(s1: Subsitution, s2: Subsitution): Subsitution {
   const composedSubst: Subsitution = {}
@@ -199,18 +199,21 @@ type TYPE = NAMED | VAR | FUNCTION
 function infer(node: es.Node, ctx: Ctx): [TYPE, Subsitution] {
   const env = ctx.env
   switch (node.type) {
-    case 'BinaryExpression':  {
+    case 'BinaryExpression': {
       const [inferredLeft, leftSubst] = infer(node.left, ctx)
       const [inferredRight, rightSubst] = infer(node.right, ctx)
       let composedSubst = composeSubsitutions(leftSubst, rightSubst)
 
-      const funcType = env[node.operator] as FUNCTION;
-      const newType = newTypeVar(ctx);
-      const subst1 = unify({ 
-        nodeType: 'Function', 
-        fromTypes: [inferredLeft, inferredRight], 
-        toType: newType}, 
-      funcType)
+      const funcType = env[node.operator] as FUNCTION
+      const newType = newTypeVar(ctx)
+      const subst1 = unify(
+        {
+          nodeType: 'Function',
+          fromTypes: [inferredLeft, inferredRight],
+          toType: newType
+        },
+        funcType
+      )
 
       composedSubst = composeSubsitutions(composedSubst, subst1)
       const inferredReturnType = applySubstToType(composedSubst, funcType.toType)
@@ -347,21 +350,21 @@ function infer(node: es.Node, ctx: Ctx): [TYPE, Subsitution] {
   }
 }
 
-//=======================================
+// =======================================
 // Private Helper Parsing Functions
-//=======================================
+// =======================================
 
 function tNamedBool(): NAMED {
   return {
-      nodeType: "Named",
-      name: 'boolean'
-  };
+    nodeType: 'Named',
+    name: 'boolean'
+  }
 }
 
 function tNamedNumber(): NAMED {
   return {
-    nodeType: "Named",
-    name: "number"
+    nodeType: 'Named',
+    name: 'number'
   }
 }
 
@@ -369,20 +372,20 @@ function tFunc(...types: TYPE[]): FUNCTION {
   const fromTypes = types.slice(0, -1)
   const toType = types.slice(-1)[0]
   return {
-      nodeType: 'Function',
-      fromTypes: fromTypes,
-      toType: toType
-  };
+    nodeType: 'Function',
+    fromTypes,
+    toType
+  }
 }
 
 const initialEnv = {
-    "true": tNamedBool(),
-    "false": tNamedBool(),
-    "!": tFunc(tNamedBool(), tNamedBool()),
-    "&&": tFunc(tNamedBool(), tNamedBool(), tNamedBool()),
-    "||": tFunc(tNamedBool(), tNamedBool(), tNamedBool()),
-    // NOTE for now just handle for Number === Number
-    "===": tFunc(tNamedNumber(), tNamedNumber(), tNamedBool()),
-    // "Bool==": tFunc(tNamedBool(), tNamedBool(), tNamedBool()),
-    "+": tFunc(tNamedNumber(), tNamedNumber(), tNamedNumber())
-};
+  // true: tNamedBool(),
+  // false: tNamedBool(),
+  '!': tFunc(tNamedBool(), tNamedBool()),
+  '&&': tFunc(tNamedBool(), tNamedBool(), tNamedBool()),
+  '||': tFunc(tNamedBool(), tNamedBool(), tNamedBool()),
+  // NOTE for now just handle for Number === Number
+  '===': tFunc(tNamedNumber(), tNamedNumber(), tNamedBool()),
+  // "Bool==": tFunc(tNamedBool(), tNamedBool(), tNamedBool()),
+  '+': tFunc(tNamedNumber(), tNamedNumber(), tNamedNumber())
+}


### PR DESCRIPTION
2 main changes:

1. remove calls to `typecheck` in `index.ts` so that we don't have to use dead code hacks to break tests
2. add support to type inference binary expressions. This requires defining primitive functions like `+`, `===` etc. I punted defining polymorphic functions since we intend to add that functionality in soon