### PR TITLE
Generate type inferred annotated AST

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn tslint --fix && yarn format && yarn tslint",
+      "pre-commit": "yarn format && yarn tslint",
       "pre-push": "yarn ci"
     }
   }

--- a/src/__tests__/typeChecker.test.ts
+++ b/src/__tests__/typeChecker.test.ts
@@ -11,17 +11,16 @@ function parse(code: any) {
 }
 
 describe('generated AST with annotated types', () => {
-
   it('returns a valid AST for simple primitive operations', () => {
     const code = 'const a = 5; const b = 4; const c = a + b; const d = c > 5;'
     const program = parse(code)
     const ast = typeCheck(program)
 
     expect(ast).toHaveLength(4)
-    expect(ast[0].init.inferredType).toEqual({name: 'number', kind: 'primitive'})
-    expect(ast[1].init.inferredType).toEqual({name: 'number', kind: 'primitive'})
-    expect(ast[2].init.inferredType).toEqual({name: 'number', kind: 'primitive'})
-    expect(ast[3].init.inferredType).toEqual({name: 'boolean', kind: 'primitive'})
+    expect(ast[0].init.inferredType).toEqual({ name: 'number', kind: 'primitive' })
+    expect(ast[1].init.inferredType).toEqual({ name: 'number', kind: 'primitive' })
+    expect(ast[2].init.inferredType).toEqual({ name: 'number', kind: 'primitive' })
+    expect(ast[3].init.inferredType).toEqual({ name: 'boolean', kind: 'primitive' })
   })
 
   it('returns valid AST for function declaration and application', () => {
@@ -32,11 +31,11 @@ describe('generated AST with annotated types', () => {
     // the first node is not saving the function spec
     expect(ast[0].id.inferredType).toEqual({
       kind: 'function',
-      argumentTypes: [{name: 'number', kind: 'primitive'}],
-      resultType: {name: 'number', kind: 'primitive'}
+      argumentTypes: [{ name: 'number', kind: 'primitive' }],
+      resultType: { name: 'number', kind: 'primitive' }
     })
     expect(ast[1].init.type).toEqual('CallExpression')
-    expect(ast[1].init.inferredType).toEqual({name: 'number', kind: 'primitive'})
+    expect(ast[1].init.inferredType).toEqual({ name: 'number', kind: 'primitive' })
   })
 
   it('returns a valid AST for simple program', () => {

--- a/src/__tests__/typeChecker.test.ts
+++ b/src/__tests__/typeChecker.test.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:object-literal-key-quotes */
 // import { typeCheck } from '../typeChecker'
 import { createContext } from '../index'
 import { parse as __parse } from '../parser'
@@ -17,10 +18,10 @@ describe('generated AST with annotated types', () => {
     const ast = typeCheck(program)
 
     expect(ast).toHaveLength(4)
-    expect(ast[0].init.inferredType).toEqual({ name: 'number', kind: 'primitive' })
-    expect(ast[1].init.inferredType).toEqual({ name: 'number', kind: 'primitive' })
-    expect(ast[2].init.inferredType).toEqual({ name: 'number', kind: 'primitive' })
-    expect(ast[3].init.inferredType).toEqual({ name: 'boolean', kind: 'primitive' })
+    expect(ast[0]['init']['inferredType']).toEqual({ name: 'number', kind: 'primitive' })
+    expect(ast[1]['init']['inferredType']).toEqual({ name: 'number', kind: 'primitive' })
+    expect(ast[2]['init']['inferredType']).toEqual({ name: 'number', kind: 'primitive' })
+    expect(ast[3]['init']['inferredType']).toEqual({ name: 'boolean', kind: 'primitive' })
   })
 
   it('returns valid AST for function declaration and application', () => {
@@ -29,13 +30,13 @@ describe('generated AST with annotated types', () => {
     const ast = typeCheck(program)
     expect(ast).toHaveLength(2)
     // the first node is not saving the function spec
-    expect(ast[0].id.inferredType).toEqual({
+    expect(ast[0]['id']['inferredType']).toEqual({
       kind: 'function',
       argumentTypes: [{ name: 'number', kind: 'primitive' }],
       resultType: { name: 'number', kind: 'primitive' }
     })
-    expect(ast[1].init.type).toEqual('CallExpression')
-    expect(ast[1].init.inferredType).toEqual({ name: 'number', kind: 'primitive' })
+    expect(ast[1]['init']['type']).toEqual('CallExpression')
+    expect(ast[1]['init']['inferredType']).toEqual({ name: 'number', kind: 'primitive' })
   })
 
   it('returns a valid AST for simple program', () => {

--- a/src/__tests__/typeChecker.test.ts
+++ b/src/__tests__/typeChecker.test.ts
@@ -10,6 +10,46 @@ function parse(code: any) {
   return program
 }
 
+describe('generated AST with annotated types', () => {
+  it('returns a valid AST for simple program', () => {
+    const program = parse('1 + 1;')
+    const expectedAST = [{
+      "expression": {
+        "type": "BinaryExpression",
+        "inferredType": { "kind": "primitive", "name": "number" },
+        "start": 0,
+        "end": 5,
+        "left": {
+          "type": "Literal",
+          "inferredType": { "kind": "primitive", "name": "number" },
+          "start": 0,
+          "end": 1,
+          "value": 1,
+          "raw": "1"
+        },
+        "operator": "+",
+        "right": {
+          "type": "Literal",
+          "inferredType": { "kind": "primitive", "name": "number" },
+          "start": 4,
+          "end": 5,
+          "value": 1,
+          "raw": "1"
+        },
+      },
+      "start": 0,
+      "end": 6,
+      "inferredType": {
+        "name": "undefined",
+        "kind": "primitive"
+      },
+      "type": "ExpressionStatement"
+    }]
+    const ast = typeCheck(program)
+    expect(ast).toEqual(expectedAST)
+  })
+})
+
 describe('type checking builtin functions', () => {
   it('no errors for well defined use of builtin functions', () => {
     /**

--- a/src/typeChecker.ts
+++ b/src/typeChecker.ts
@@ -1,6 +1,5 @@
 import * as es from 'estree'
-// tslint:disable:no-console
-// tslint:disable: object-literal-key-quotes
+/* tslint:disable:object-literal-key-quotes no-console*/
 /**
  * An additional layer of typechecking to be done right after parsing.
  * @param program Parsed Program
@@ -223,7 +222,7 @@ function inferredTypeSpec(type: TYPE): object {
  */
 function saveType(inferred: [TYPE, Subsitution], copiedNode: object): void {
   const type = inferred[0]
-  copiedNode.inferredType = inferredTypeSpec(type)
+  copiedNode['inferredType'] = inferredTypeSpec(type) 
 }
 
 function saveTypeAndReturn(inferred: [TYPE, Subsitution], copiedNode: object): [TYPE, Subsitution] {
@@ -430,7 +429,7 @@ function infer(
        * Before returning, save function inferred type into the id child of FunctionDeclaration
        * from that saved in the env.
        */
-      saveType([env[id.name], {}], copiedNode.id)
+      saveType([env[id.name], {}], copiedNode['id'])
       return saveTypeAndReturn([tNamedUndef, composedSubst], copiedNode)
     }
     case 'CallExpression': {

--- a/src/typeChecker.ts
+++ b/src/typeChecker.ts
@@ -202,7 +202,7 @@ function inferredTypeSpec(type: TYPE): object {
   switch (type.nodeType) {
     case 'Named':
       // all Named nodeTypes are primitive
-      return { name: type.name, kind: 'primitive'}
+      return { name: type.name, kind: 'primitive' }
     case 'Function':
       const result = {
         kind: 'function',
@@ -578,7 +578,6 @@ const primitiveFuncs = {
   '-': tFunc(tNamedNumber, tNamedNumber, tNamedNumber),
   '*': tFunc(tNamedNumber, tNamedNumber, tNamedNumber)
   // '/': tFunc(tNamedNumber(), tNamedNumber(), tNamedNumber())
-
 }
 
 const initialEnv = {


### PR DESCRIPTION
My first attempt at generating the type inferred annotated AST. Considering how the `infer` function is essentially a dfs traveral, I add parameters to the `infer` function so that nodes were copied and child pointers created as `infer` traverses the AST. This leads to a rather clumsy refactor of the code where all `return` statements of `infer` needs to be wrapped with `saveTypeAndReturn` call that saves the type in the `inferredType` field of the copied node. 

I am still unclear with how the annotated AST should look like but that can be easily changed in subsequent PRs. This would give more clarity in what types are being inferred instead of relying on `Error` or lack thereof to assert type correctness. 